### PR TITLE
Change theme installation directory and set GRUB_GFXMODE auto

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,8 @@
 # * @link    https://youtu.be/BAyzHP1Cqb0
 # */
 
-THEME_DIR='/usr/share/grub/themes'
+#THEME_DIR='/usr/share/grub/themes'
+THEME_DIR='/boot/grub/themes'
 THEME_NAME=''
 
 function echo_title() {     echo -ne "\033[1;44;37m${*}\033[0m\n"; }

--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,16 @@ function config_grub() {
 
     echo_info "echo \"GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"\" >> /etc/default/grub"
     echo "GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"" >> /etc/default/grub
+    
+    #--------------------------------------------------
+
+    echo_primary 'Setting grub graphics mode to auto'
+    # remove default timeout if any
+    echo_info "sed -i '/GRUB_GFXMODE=/d' /etc/default/grub"
+    sed -i '/GRUB_GFXMODE=/d' /etc/default/grub
+
+    echo_info "echo 'GRUB_GFXMODE=\"auto\"' >> /etc/default/grub"
+    echo 'GRUB_GFXMODE="auto"' >> /etc/default/grub   
 }
 
 function update_grub() {


### PR DESCRIPTION
Resolves issue when installing to encrypted disk where grub cannot access /usr partition.

Errors produced by previous commit:
"error: no such device: xxxxx-xxxxxx-xxxxx-xxxxxx
error: no server is specified"

And fixes issue where if GRUB_GFXMODE is incorrect, themes do not display
