### PR TITLE
fix(install.sh): change fedora's grub config output path to `/boot/grub2/grub.cfg`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ function config_grub() {
 
     echo_info "echo \"GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"\" >> /etc/default/grub"
     echo "GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"" >> /etc/default/grub
-    
+
     #--------------------------------------------------
 
     echo_primary 'Setting grub graphics mode to auto'
@@ -140,7 +140,7 @@ function config_grub() {
     sed -i '/GRUB_GFXMODE=/d' /etc/default/grub
 
     echo_info "echo 'GRUB_GFXMODE=\"auto\"' >> /etc/default/grub"
-    echo 'GRUB_GFXMODE="auto"' >> /etc/default/grub   
+    echo 'GRUB_GFXMODE="auto"' >> /etc/default/grub
 }
 
 function update_grub() {
@@ -155,13 +155,9 @@ function update_grub() {
         grub-mkconfig -o /boot/grub/grub.cfg
 
     elif [[ -x "$(command -v grub2-mkconfig)" ]]; then
-        if [[ -x "$(command -v zypper)" ]]; then
+        if [[ -x "$(command -v zypper)" || -x "$(command -v dnf)" ]]; then
             echo_info 'grub2-mkconfig -o /boot/grub2/grub.cfg'
             grub2-mkconfig -o /boot/grub2/grub.cfg
-
-        elif [[ -x "$(command -v dnf)" ]]; then
-            echo_info 'grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg'
-            grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
         fi
     fi
 }


### PR DESCRIPTION
On Fedora 42, the script will fail when attempting to update the grub config.

This is the output it gives:
```
Updating grub config...
grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
Running `grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg' will overwrite the GRUB wrapper.
Please run `grub2-mkconfig -o /boot/grub2/grub.cfg' instead to update grub.cfg.
GRUB configuration file was not updated.
Boot Theme Update Successful!
```

After some digging around, this [forum post](https://discussion.fedoraproject.org/t/boot-loader-problem-on-efi-system/116233/5) says that `/boot/efi/EFI/fedora/grub.cfg` is just a stub that redirects to `/boot/grub2/grub.cfg`. (Update: [official fedora docs](https://docs.fedoraproject.org/en-US/quick-docs/grub2-bootloader/#create-a-grub-2-configuration) confirms this).

So the solution was to change the grub config output path to `/boot/grub2/grub.cfg`.